### PR TITLE
Allow setting api key and model in config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ name = "chatgpt-cli"
 version = "0.3.1"
 dependencies = [
  "clap",
- "dirs",
+ "directories",
  "reqwest",
  "rustix 0.36.8",
  "serde",
@@ -171,23 +171,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
+name = "directories"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -653,6 +654,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.2.2", features = ["derive"] }
-dirs = "4.0.0"
+directories = "5.0.1"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 rustix = {version = "0.36.8", features = ["process"]}
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "chatgpt-cli"
 email = "jrg2156@gmail.com"
-authors = ["Juan Gonzalez"]
-version = "0.3.1"
+authors = ["Juan Gonzalez", "Robert Offner"]
+version = "0.4.0"
 edition = "2021"
 description = "Talk with ChatGPT from your terminal"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -17,11 +17,9 @@ export PATH="$PATH:$HOME/.cargo/bin"
 
 Finally, you'll need a OPENAI API key (you can get one [here](https://platform.openai.com/account/api-keys)), and you'll need to export your API Key as an environment variable:
 
-
 ```
 export OPENAI_API_KEY=<your api key>
 ```
-
 
 Then you can start a conversation with ChatGPT:
 
@@ -39,9 +37,32 @@ chatgpt '''
     '''
 ```
 
-Your messages in each terminal window are saved to `~/.chatgpt/{OS boot time}/{terminal pid}/chatlog.json`. This means you can ask follow-up questions in a terminal window and start a new conversation by opening a new window.
+Your messages in each terminal window are saved to `{data_dir}/{OS boot time}/{terminal pid}/chatlog.json`. This means you can ask follow-up questions in a terminal window and start a new conversation by opening a new window.
+
+For example on MacOS the data path is `$HOME/Library/Application Support/`. For other platforms, refer to [the directories documentation](https://github.com/dirs-dev/directories-rs#projectdirs).
 
 ## Settings
+
+The CLI is configured either by environment variables or the config file.
+
+To find out where the config file is expected to be, run `chatgpt -p`. Create that file and populate it with the below values to use it.
+
+The CLI will always use CLI flags over environment variables over the config file.
+
+### Specify the API key
+
+You can specify the API key either via an environment variable or in the `config.json` file:
+
+```
+export OPENAI_API_KEY=<your api key>
+```
+
+`config.json`
+```
+{
+  "openai_api_key": "<your api key>"
+}
+```
 
 ### Use a different model like GPT-4
 
@@ -59,7 +80,16 @@ You can also change the default model by setting the `CHATGPT_CLI_MODEL` environ
 export CHATGPT_CLI_MODEL=gpt-4
 ```
 
-NOTE: The gpt-4 model is not yet available to everyone. You can join the wailist [here](https://openai.com/waitlist/gpt-4-api).
+Or add this to the config file:
+
+`config.json`
+```
+{
+  "model": "<gpt-4>"
+}
+```
+
+NOTE: The gpt-4 model is not yet available to everyone. You can join the waitlist [here](https://openai.com/waitlist/gpt-4-api).
 
 ### Increase the request timeout
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,15 @@ fn main() -> Result<(), Error> {
     let project_path = directories::ProjectDirs::from("com", "gitznik", "chatgpt-cli")
         .expect("Could not find valid application path");
 
-    let config_file_path = fs::read(project_path.config_dir().join("config.json")).ok();
-    let config_file = if let Some(config_file_path) = config_file_path {
+    let config_file_path = project_path.config_dir().join("config.json");
+    if args.print_config_path {
+        println!(
+            "Config file is expected here: {}",
+            config_file_path.to_str().expect("Could not display the config path")
+        );
+    };
+    let config_file = fs::read(config_file_path).ok();
+    let config_file = if let Some(config_file_path) = config_file {
         serde_json::from_slice::<Config>(&config_file_path).unwrap_or(Config::default())
     } else {
         Config::default()
@@ -204,4 +211,8 @@ struct CliArgs {
     /// The ChatGPT model to use (default: gpt-3.5-turbo)
     #[clap(short, long)]
     model: Option<String>,
+
+    /// Print where the config file is expected to be located
+    #[clap(short, long)]
+    print_config_path: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,12 +44,15 @@ fn main() -> Result<(), Error> {
         .expect("Could not find valid application path");
 
     let config_file_path = project_path.config_dir().join("config.json");
+
     if args.print_config_path {
         println!(
             "Config file is expected here: {}",
             config_file_path.to_str().expect("Could not display the config path")
         );
     };
+
+    // Read the config file. If it does not exist, create an empty config struct
     let config_file = fs::read(config_file_path).ok();
     let config_file = if let Some(config_file_path) = config_file {
         serde_json::from_slice::<Config>(&config_file_path).unwrap_or(Config::default())
@@ -57,7 +60,7 @@ fn main() -> Result<(), Error> {
         Config::default()
     };
 
-    // get OPENAI_API_KEY from environment variable
+    // get OPENAI_API_KEY from environment variable or config file
     let key = "OPENAI_API_KEY";
     let openai_api_key_env = env::var(key).ok();
     let openai_api_key = openai_api_key_env.unwrap_or_else(|| {
@@ -66,7 +69,7 @@ fn main() -> Result<(), Error> {
             .expect("No api key defined in config or env")
     });
 
-    // Get the model from the CLI argument, environment variable, or use the default value
+    // Get the model from the CLI argument, environment variable, config file, or use the default value
     let model = args
         .model
         .or_else(|| env::var("CHATGPT_CLI_MODEL").ok())
@@ -104,7 +107,7 @@ fn main() -> Result<(), Error> {
     let mut chatlog_text = String::new();
     file.read_to_string(&mut chatlog_text)?;
 
-    // get the messages from the chatlog. limit the total number of tokens to 3000
+    // get the messages from the chatlog. limit the total number of tokens to 2000
     const MAX_TOKENS: i64 = 2000;
     let mut total_tokens: i64 = 0;
     let mut messages: Vec<Message> = vec![];

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use dirs;
 use reqwest::blocking::Client;
 use reqwest::header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE};
 use rustix::process;
@@ -7,8 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::fs::OpenOptions;
 use std::time::Duration;
 use std::{
-    env,
-    fs::{self},
+    env, fs,
     io::{Error, Read},
 };
 use sys_info::boottime;
@@ -54,9 +52,8 @@ fn main() -> Result<(), Error> {
     let boot_time_since_unix_epoch = boot_time.tv_sec;
 
     // load the chatlog for this terminal window
-    let chatlog_path = dirs::home_dir()
-        .expect("Failed to get home directory")
-        .join(".chatgpt")
+    let chatlog_path = project_path
+        .data_dir()
         .join(boot_time_since_unix_epoch.to_string())
         .join(
             process::getppid()


### PR DESCRIPTION
This way they don't have to be exposed in dotfiles. 

For this I moved to the `directories` crate, which also changes the chat history location out of the root. I felt that's a bit cleaner.

I added a flag to print where the config file is expected to be.